### PR TITLE
install as Dev Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Swipable items wrapper component for Svelte :fire: :boom: (zero dependencies - 3
 ## Installation
 
 ```bash
-npm install -D svelte-swipe
+npm i -D svelte-swipe
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Swipable items wrapper component for Svelte :fire: :boom: (zero dependencies - 3
 ## Installation
 
 ```bash
-npm i svelte-swipe
+npm install -D svelte-swipe
 ```
 
 ## Usage


### PR DESCRIPTION
as to obey to the [documentation](https://github.com/sveltejs/sapper-template#using-external-components) 

> When using Svelte components installed from npm, such as @sveltejs/svelte-virtual-list, Svelte needs the original component source (rather than any precompiled JavaScript that ships with the component). This allows the component to be rendered server-side, and also keeps your client-side app smaller.
> Because of that, it's essential that the bundler doesn't treat the package as an external dependency. You can either modify the external option under server in rollup.config.js or the externals option in webpack.config.js, or simply install the package to devDependencies rather than dependencies, which will cause it to get bundled (and therefore compiled) with your app: