### PR TITLE
fix "fire" variable missing and remove console.log

### DIFF
--- a/src/lib/components/Swipe.svelte
+++ b/src/lib/components/Swipe.svelte
@@ -1,7 +1,7 @@
 <script>
   // @ts-nocheck
 
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, createEventDispatcher } from 'svelte';
   import SwipeSnap from '../helpers/SwipeSnap';
 
   /**
@@ -64,6 +64,7 @@
   let played = defaultIndex || 0;
   let run_interval = false;
   let autoplay_pause = false;
+  const fire = createEventDispatcher();
 
   function init() {
     Swiper = new SwipeSnap({

--- a/src/lib/helpers/SwipeSnap.js
+++ b/src/lib/helpers/SwipeSnap.js
@@ -190,8 +190,6 @@ transition-duration: ${touch_end ? this.transition_duration : '0'}ms;
     this.active_item = this.active_indicator;
     this.default_index = this.active_item;
 
-    console.log(this.active_indicator);
-
     this.setElementsPosition({
       end: true,
       elems: [...this.elements],
@@ -268,7 +266,6 @@ transition-duration: ${touch_end ? this.transition_duration : '0'}ms;
   }
 
   nextItem() {
-    console.log('next item');
     let step = this.active_indicator + 1;
     this.goTo(step);
   }


### PR DESCRIPTION
just removed some console.log statements and fix the "fire" variable missing in Swipe.svelte and causing "ReferenceError: fire is not defined"